### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "`"

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 |Project|Description|
 |-------|-----------|
 |CrashLand|A small RPG|
+[![Run on Repl.it](https://repl.it/badge/github/cocochief4/StoryPath)](https://repl.it/github/cocochief4/StoryPath)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@PandaGaming725/StoryPath).